### PR TITLE
Fix compilation error by removing superfluous conversion

### DIFF
--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/ReviewEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/ReviewEditorDialog.java
@@ -79,8 +79,6 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
         getFormLayout().add(categoryBox);
 
         getBinder().forField(categoryBox)
-                .withConverter(categoryService::findCategoryOrThrow,
-                        Category::getName)
                 .bind(Review::getCategory, Review::setCategory);
     }
 


### PR DESCRIPTION
Conversion was apparently made superfluous and incorrect by new version of ComboBox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/free-starter-flow/89)
<!-- Reviewable:end -->
