### PR TITLE
Improve ux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .metadata/
 .project
 .settings/
+node_modules
 
 *.iml
 .DS_Store

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/MainLayout.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/MainLayout.java
@@ -38,7 +38,6 @@ import com.vaadin.starter.beveragebuddy.ui.views.reviewslist.ReviewsList;
  * The main layout contains the header with the navigation buttons, and the
  * child views below that.
  */
-@BodySize(height = "100vh", width = "100vw")
 @HtmlImport("frontend://styles/shared-styles.html")
 @Viewport("width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes")
 @Theme(Lumo.class)

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/AbstractEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/AbstractEditorDialog.java
@@ -148,7 +148,7 @@ public abstract class AbstractEditorDialog<T extends Serializable>
         saveButton.getElement().setAttribute("theme", "primary");
         cancelButton.addClickListener(e -> close());
         deleteButton.addClickListener(e -> deleteClicked());
-        deleteButton.getElement().setAttribute("theme", "tertiary error");
+        deleteButton.getElement().setAttribute("theme", "error");
         buttonBar.setClassName("buttons");
         buttonBar.setSpacing(true);
         add(buttonBar);

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/AbstractEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/AbstractEditorDialog.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
@@ -57,7 +57,7 @@ public abstract class AbstractEditorDialog<T extends Serializable>
      * an already existing item.
      */
     public enum Operation {
-        ADD("Add New", "add", false),
+        ADD("New", "add", false),
         EDIT("Edit", "edit", true);
 
         private final String nameInTitle;
@@ -84,7 +84,7 @@ public abstract class AbstractEditorDialog<T extends Serializable>
         }
     }
 
-    private final H2 titleField = new H2();
+    private final H3 titleField = new H3();
     private final Button saveButton = new Button("Save");
     private final Button cancelButton = new Button("Cancel");
     private final Button deleteButton = new Button("Delete");
@@ -137,8 +137,7 @@ public abstract class AbstractEditorDialog<T extends Serializable>
 
     private void initFormLayout() {
         formLayout.setResponsiveSteps(new FormLayout.ResponsiveStep("0", 1),
-                new FormLayout.ResponsiveStep("50em", 2));
-        formLayout.addClassName("no-padding");
+                new FormLayout.ResponsiveStep("25em", 2));
         Div div = new Div(formLayout);
         div.addClassName("has-padding");
         add(div);
@@ -149,7 +148,7 @@ public abstract class AbstractEditorDialog<T extends Serializable>
         saveButton.getElement().setAttribute("theme", "primary");
         cancelButton.addClickListener(e -> close());
         deleteButton.addClickListener(e -> deleteClicked());
-        deleteButton.getElement().setAttribute("theme", "tertiary danger");
+        deleteButton.getElement().setAttribute("theme", "tertiary error");
         buttonBar.setClassName("buttons");
         buttonBar.setSpacing(true);
         add(buttonBar);
@@ -214,9 +213,6 @@ public abstract class AbstractEditorDialog<T extends Serializable>
             close();
         } else {
             BinderValidationStatus<T> status = binder.validate();
-            Notification.show(status.getValidationErrors().stream()
-                    .map(ValidationResult::getErrorMessage)
-                    .collect(Collectors.joining("; ")), 3000, Position.BOTTOM_START);
         }
     }
 

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/ConfirmationDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/ConfirmationDialog.java
@@ -18,7 +18,7 @@ package com.vaadin.starter.beveragebuddy.ui.common;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.shared.Registration;
 
@@ -28,14 +28,14 @@ import java.util.function.Consumer;
 
 /**
  * A generic dialog for confirming or cancelling an action.
- * 
+ *
  * @param <T>
  *            The type of the action's subject
  */
 class ConfirmationDialog<T extends Serializable>
         extends Dialog {
 
-    private final H2 titleField = new H2();
+    private final H3 titleField = new H3();
     private final Div messageLabel = new Div();
     private final Div extraMessageLabel = new Div();
     private final Button confirmButton = new Button();
@@ -50,7 +50,6 @@ class ConfirmationDialog<T extends Serializable>
         setCloseOnEsc(true);
         setCloseOnOutsideClick(false);
 
-        getElement().getClassList().add("confirm-dialog");
         confirmButton.addClickListener(e -> close());
         confirmButton.getElement().setAttribute("theme", "tertiary");
         confirmButton.setAutofocus(true);
@@ -59,12 +58,12 @@ class ConfirmationDialog<T extends Serializable>
 
         HorizontalLayout buttonBar = new HorizontalLayout(confirmButton,
                 cancelButton);
-        buttonBar.setClassName("confirm-dialog-buttons");
+        buttonBar.setClassName("buttons confirm-buttons");
 
         Div labels = new Div(messageLabel, extraMessageLabel);
         labels.setClassName("confirm-text");
 
-        titleField.setClassName("confirm-dialog-heading");
+        titleField.setClassName("confirm-title");
 
         add(titleField, labels, buttonBar);
 
@@ -117,8 +116,15 @@ class ConfirmationDialog<T extends Serializable>
         }
         registrationForCancel = cancelButton
                 .addClickListener(e -> cancelHandler.run());
+        this.addOpenedChangeListener(e -> {
+            if (!e.isOpened()) {
+               // TODO this should not be run when the dialog is closed by confirmation
+               // Now it produces an RPC warning
+               cancelHandler.run();
+            }
+        });
         if (isDisruptive) {
-            confirmButton.getElement().setAttribute("theme", "tertiary danger");
+            confirmButton.getElement().setAttribute("theme", "tertiary error");
         }
         open();
     }

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/ConfirmationDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/ConfirmationDialog.java
@@ -118,8 +118,6 @@ class ConfirmationDialog<T extends Serializable>
                 .addClickListener(e -> cancelHandler.run());
         this.addOpenedChangeListener(e -> {
             if (!e.isOpened()) {
-               // TODO this should not be run when the dialog is closed by confirmation
-               // Now it produces an RPC warning
                cancelHandler.run();
             }
         });

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoriesList.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoriesList.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.SelectionMode;
+import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.notification.Notification;
@@ -26,6 +28,7 @@ import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.starter.beveragebuddy.backend.Category;
@@ -43,7 +46,8 @@ import com.vaadin.starter.beveragebuddy.ui.common.AbstractEditorDialog;
 @PageTitle("Categories List")
 public class CategoriesList extends VerticalLayout {
 
-    private final TextField searchField = new TextField("", "Search");
+    private final TextField searchField = new TextField("", "Search categories");
+    private final H2 header = new H2("Categories");
     private final Grid<Category> grid = new Grid<>();
 
     private final CategoryEditorDialog form = new CategoryEditorDialog(
@@ -53,7 +57,7 @@ public class CategoriesList extends VerticalLayout {
         initView();
 
         addSearchBar();
-        addGrid();
+        addContent();
 
         updateView();
     }
@@ -70,6 +74,7 @@ public class CategoriesList extends VerticalLayout {
         searchField.setPrefixComponent(new Icon("lumo", "search"));
         searchField.addClassName("view-toolbar__search-field");
         searchField.addValueChangeListener(e -> updateView());
+        searchField.setValueChangeMode(ValueChangeMode.EAGER);
 
         Button newButton = new Button("New category", new Icon("lumo", "plus"));
         newButton.getElement().setAttribute("theme", "primary");
@@ -81,15 +86,19 @@ public class CategoriesList extends VerticalLayout {
         add(viewToolbar);
     }
 
-    private void addGrid() {
-        grid.addColumn(Category::getName).setHeader("Category");
-        grid.addColumn(this::getReviewCount).setHeader("Beverages");
+    private void addContent() {
+        VerticalLayout container = new VerticalLayout();
+        container.setClassName("view-container");
+        container.setAlignItems(Alignment.STRETCH);
+
+        grid.addColumn(Category::getName).setHeader("Name").setWidth("8em").setResizable(true);
+        grid.addColumn(this::getReviewCount).setHeader("Beverages").setWidth("6em");
         grid.addColumn(new ComponentRenderer<>(this::createEditButton))
                 .setFlexGrow(0);
-        
-        grid.addClassName("categories");
-        grid.getElement().setAttribute("theme", "row-dividers");
-        add(grid);
+        grid.setSelectionMode(SelectionMode.NONE);
+
+        container.add(header, grid);
+        add(container);
     }
 
     private Button createEditButton(Category category) {
@@ -112,6 +121,12 @@ public class CategoriesList extends VerticalLayout {
         List<Category> categories = CategoryService.getInstance()
                 .findCategories(searchField.getValue());
         grid.setItems(categories);
+        
+        if (searchField.getValue().length() > 0) {
+            header.setText("Search for “"+ searchField.getValue() +"”");
+        } else {
+            header.setText("Categories");
+        }
     }
 
     private void saveCategory(Category category,

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoriesList.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoriesList.java
@@ -121,7 +121,7 @@ public class CategoriesList extends VerticalLayout {
         List<Category> categories = CategoryService.getInstance()
                 .findCategories(searchField.getValue());
         grid.setItems(categories);
-        
+
         if (searchField.getValue().length() > 0) {
             header.setText("Search for “"+ searchField.getValue() +"”");
         } else {

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoryEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoryEditorDialog.java
@@ -30,11 +30,11 @@ import com.vaadin.starter.beveragebuddy.ui.common.AbstractEditorDialog;
  */
 public class CategoryEditorDialog extends AbstractEditorDialog<Category> {
 
-    private final TextField categoryNameField = new TextField("Category Name");
+    private final TextField categoryNameField = new TextField("Name");
 
     public CategoryEditorDialog(BiConsumer<Category, Operation> itemSaver,
             Consumer<Category> itemDeleter) {
-        super("Category", itemSaver, itemDeleter);
+        super("category", itemSaver, itemDeleter);
 
         addNameField();
     }
@@ -59,11 +59,11 @@ public class CategoryEditorDialog extends AbstractEditorDialog<Category> {
         int reviewCount = ReviewService.getInstance()
                 .findReviews(getCurrentItem().getName()).size();
         if (reviewCount > 0) {
-            openConfirmationDialog(
-                    "Delete Category “" + getCurrentItem().getName() + "”?",
-                    "There are " + reviewCount
+            openConfirmationDialog("Delete category",
+                    "Are you sure you want to delete the “" + getCurrentItem().getName()
+                            + "” category? There are " + reviewCount
                             + " reviews associated with this category.",
-                    "Deleting the category will mark the associated reviews as “undefined”."
+                    "Deleting the category will mark the associated reviews as “undefined”. "
                             + "You may link the reviews to other categories on the edit page.");
         }
     }

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoryEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoryEditorDialog.java
@@ -64,7 +64,7 @@ public class CategoryEditorDialog extends AbstractEditorDialog<Category> {
                             + "” category? There are " + reviewCount
                             + " reviews associated with this category.",
                     "Deleting the category will mark the associated reviews as “undefined”. "
-                            + "You may link the reviews to other categories on the edit page.");
+                            + "You can edit individual reviews to select another category.");
         }
     }
 }

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/reviewslist/ReviewEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/reviewslist/ReviewEditorDialog.java
@@ -48,7 +48,7 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
 
     public ReviewEditorDialog(BiConsumer<Review, Operation> saveHandler,
             Consumer<Review> deleteHandler) {
-        super("Review", saveHandler, deleteHandler);
+        super("review", saveHandler, deleteHandler);
 
         createNameField();
         createTimesField();
@@ -134,9 +134,8 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
 
     @Override
     protected void confirmDelete() {
-        openConfirmationDialog(
-                "Delete beverage \"" + getCurrentItem().getName() + "\"?", "",
-                "");
+        openConfirmationDialog("Delete review",
+                "Are you sure you want to delete the review for “" + getCurrentItem().getName() + "”?", "");
     }
 
 }

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/reviewslist/ReviewEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/reviewslist/ReviewEditorDialog.java
@@ -51,9 +51,9 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
         super("review", saveHandler, deleteHandler);
 
         createNameField();
-        createTimesField();
         createCategoryBox();
         createDatePicker();
+        createTimesField();
         createScoreBox();
     }
 
@@ -73,7 +73,7 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
     }
 
     private void createDatePicker() {
-        lastTasted.setLabel("Date");
+        lastTasted.setLabel("Last tasted");
         lastTasted.setRequired(true);
         lastTasted.setMax(LocalDate.now());
         lastTasted.setMin(LocalDate.of(1, 1, 1));

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/reviewslist/ReviewEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/reviewslist/ReviewEditorDialog.java
@@ -58,7 +58,7 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
     }
 
     private void createScoreBox() {
-        scoreBox.setLabel("Mark a score");
+        scoreBox.setLabel("Rating");
         scoreBox.setRequired(true);
         scoreBox.setAllowCustomValue(false);
         scoreBox.setItems("1", "2", "3", "4", "5");
@@ -73,7 +73,7 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
     }
 
     private void createDatePicker() {
-        lastTasted.setLabel("Choose the date");
+        lastTasted.setLabel("Date");
         lastTasted.setRequired(true);
         lastTasted.setMax(LocalDate.now());
         lastTasted.setMin(LocalDate.of(1, 1, 1));
@@ -91,7 +91,7 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
     }
 
     private void createCategoryBox() {
-        categoryBox.setLabel("Choose a category");
+        categoryBox.setLabel("Category");
         categoryBox.setRequired(true);
         categoryBox.setItemLabelGenerator(Category::getName);
         categoryBox.setAllowCustomValue(false);
@@ -120,7 +120,7 @@ public class ReviewEditorDialog extends AbstractEditorDialog<Review> {
     }
 
     private void createNameField() {
-        beverageName.setLabel("Beverage name");
+        beverageName.setLabel("Beverage");
         beverageName.setRequired(true);
         getFormLayout().add(beverageName);
 

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/reviewslist/ReviewsList.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/reviewslist/ReviewsList.java
@@ -18,7 +18,7 @@ package com.vaadin.starter.beveragebuddy.ui.views.reviewslist;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
@@ -66,16 +66,16 @@ public class ReviewsList extends PolymerTemplate<ReviewsModel> {
     @Id("newReview")
     private Button addReview;
     @Id("header")
-    private H1 header;
+    private H2 header;
 
     private ReviewEditorDialog reviewForm = new ReviewEditorDialog(
             this::saveUpdate, this::deleteUpdate);
 
     public ReviewsList() {
-        search.setPlaceholder("Search");
+        search.setPlaceholder("Search reviews");
         search.addValueChangeListener(e -> updateList());
         search.setValueChangeMode(ValueChangeMode.EAGER);
-        
+
         addReview.addClickListener(e -> openForm(new Review(),
                 AbstractEditorDialog.Operation.ADD));
 

--- a/src/main/webapp/frontend/src/views/reviewslist/reviews-list.html
+++ b/src/main/webapp/frontend/src/views/reviewslist/reviews-list.html
@@ -20,6 +20,7 @@
 <link rel="import" href="../../../bower_components/vaadin-text-field/src/vaadin-text-field.html">
 <link rel="import" href="../../../bower_components/vaadin-button/src/vaadin-button.html">
 <link rel="import" href="../../../bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="../../../bower_components/vaadin-lumo-styles/badge.html">
 <!-- TODO Needed to show icons in Vaadin Designer preview mode for now, but can be removed soon -->
 <link rel="import" href="../../../bower_components/vaadin-lumo-styles/icons.html">
 
@@ -27,41 +28,12 @@
 <!-- Defines the reviews-list element -->
 <dom-module id="reviews-list">
     <template>
-        <style>
+        <style include="lumo-color lumo-typography lumo-badge view-styles">
             :host {
                 display: block;
             }
 
-            /* Stretch to fill the entire browser viewport while keeping the content constrained to
-               parent element max-width */
-            .view-toolbar,
-            .reviews {
-                margin: 0 calc(-50vw + 50%);
-                padding: 8px calc(50vw - 50% + 16px);
-            }
-
-            .view-toolbar {
-                display: flex;
-                min-height: 45px;
-                background-color: var(--lumo-base-color);
-                box-shadow: 0 1px 0 0 var(--lumo-contrast-5pct);
-            }
-
-            #search {
-                flex: auto;
-                margin-right: 16px;
-            }
-
-            vaadin-button {
-                margin-left: 0;
-                margin-right: 0;
-                min-width: 0;
-                flex: none;
-            }
-
-            h1 {
-                letter-spacing: -0.015em;
-                line-height: 1.1;
+            #header {
                 display: flex;
                 justify-content: space-between;
                 flex-wrap: wrap;
@@ -69,20 +41,22 @@
             }
 
             /* Subtitle for the header */
-            h1 span {
+            #header span {
                 display: block;
-                font-size: 14px;
+                font-size: var(--lumo-font-size-s);
                 font-weight: 400;
-                color: var(--lumo-tertiary-text-color);
+                color: var(--lumo-secondary-text-color);
                 letter-spacing: 0;
                 margin-top: 0.3em;
+                margin-left: auto;
             }
 
             .review {
                 display: flex;
                 align-items: center;
                 width: 100%;
-                padding: 24px 32px;
+                padding: var(--lumo-space-wide-xl);
+                padding-right: var(--lumo-space-m);
                 box-sizing: border-box;
                 margin-bottom: 8px;
                 background-color: var(--lumo-base-color);
@@ -162,27 +136,23 @@
             }
 
             .review__details {
-                width: 70%;
+                width: 100%;
+                max-width: calc(100% - 8.5em);
                 flex: auto;
-                line-height: 1.2em;
+                line-height: var(--lumo-line-height-xs);
+                overflow: hidden;
             }
 
             .review__name {
-                margin: 0;
-                font-weight: 600;
-                color: var(--lumo-header-text-color);
-                margin-bottom: 0.3em;
+                margin: 0 0.5em 0 0;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
             }
 
             .review__category {
-                display: inline-block;
                 margin: 0;
-                font-size: 12px;
-                font-weight: 500;
-                background-color: var(--lumo-primary-color-10pct);
-                color: var(--lumo-primary-text-color);
-                border-radius: calc(var(--lumo-border-radius) / 2);
-                padding: 0 0.5em;
+                flex: none;
             }
 
             /* We only expect to have 10 categories at most, after which the colors start to rotate */
@@ -193,22 +163,28 @@
 
             .review__date {
                 white-space: nowrap;
-                line-height: 1.3;
+                line-height: var(--lumo-line-height-xs);
                 margin: 0 1em;
-                flex-grow: auto;
                 width: 30%;
             }
 
             .review__date h5 {
-                font-size: 13px;
+                font-size: var(--lumo-font-size-s);
                 font-weight: 400;
                 color: var(--lumo-secondary-text-color);
                 margin: 0;
             }
 
             .review__date p {
+                font-size: var(--lumo-font-size-s);
                 margin: 0;
-                font-size: 15px;
+            }
+
+            .review__edit {
+                align-self: flex-start;
+                flex: none;
+                margin: 0 0 0 auto;
+                width: 5em;
             }
 
             .reviews__no-matches {
@@ -222,43 +198,34 @@
 
             /* Small viewport styles */
 
-            @media (max-width: 600px) {
-                .view-toolbar,
-                .reviews {
-                    padding: 4px 8px;
-                }
-
-                /* Hide the button label when the browser viewport is narrow */
-                vaadin-button span {
-                    display: none;
-                }
-
-                vaadin-button iron-icon {
-                    margin: 0;
-                }
-
+            @media (max-width: 500px) {
                 .review {
-                    padding: 16px;
+                    padding: var(--lumo-space-m);
+                    padding-right: var(--lumo-space-s);
+                    flex-wrap: wrap;
                 }
 
-                .review__name {
-                    display: inline;
+                .review__date {
+                    order: 1;
+                    margin-left: 3.5em;
+                    margin-top: 0.5em;
                 }
             }
 
         </style>
 
         <div class="view-toolbar">
-            <vaadin-text-field id="search" autocapitalize=off>
+            <vaadin-text-field id="search" class="view-toolbar__search-field" autocapitalize=off>
                 <iron-icon icon="lumo:search" slot="prefix"></iron-icon>
             </vaadin-text-field>
-            <vaadin-button id="newReview" theme="primary">
-                <iron-icon icon="lumo:plus"></iron-icon><span>New review</span>
+            <vaadin-button id="newReview" class="view-toolbar__button" theme="primary">
+                <iron-icon icon="lumo:plus" slot="prefix"></iron-icon>
+                <span>New review</span>
             </vaadin-button>
         </div>
 
-        <div class="reviews">
-            <h1 id="header"></h1>
+        <div class="view-container reviews">
+            <h2 id="header"></h2>
             <template is="dom-if" if="{{!_isEmpty(reviews)}}">
                 <template is="dom-repeat" items="[[reviews]]">
                     <div class="review">
@@ -272,15 +239,15 @@
                         <div class="review__details">
                             <h4 class="review__name">[[item.name]]</h4>
                             <template is="dom-if" if="[[item.category]]">
-                                <p class="review__category" style$="--category: [[item.category.id]];">[[item.category.name]]</p>
+                                <p class="review__category" theme="badge small" style$="--category: [[item.category.id]];">[[item.category.name]]</p>
                             </template>
                             <template is="dom-if" if="[[!item.category]]">
                                 <p class="review__category" style="--category: -1;">Undefined</p>
                             </template>
                         </div>
                         <div class="review__date">
-                                <h5>Last tasted</h5>
-                                <p>[[item.date]]</p>
+                            <h5>Last tasted</h5>
+                            <p>[[item.date]]</p>
                         </div>
                         <vaadin-button on-click="edit" class="review__edit" theme="tertiary">
                             <iron-icon icon="lumo:edit"></iron-icon><span>Edit</span>

--- a/src/main/webapp/frontend/styles/shared-styles.html
+++ b/src/main/webapp/frontend/styles/shared-styles.html
@@ -164,6 +164,10 @@
                     margin-left: auto;
                 }
 
+                .buttons > :nth-last-child(2) {
+                    margin-right: var(--lumo-space-m);
+                }
+
                 .confirm-buttons {
                     justify-content: space-between;
                     padding: var(--lumo-space-xs) var(--lumo-space-m);

--- a/src/main/webapp/frontend/styles/shared-styles.html
+++ b/src/main/webapp/frontend/styles/shared-styles.html
@@ -14,16 +14,54 @@
   ~ the License.
   -->
 
-<custom-style>
-    <style>
+<link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
+<link rel="import" href="../bower_components/vaadin-lumo-styles/typography.html">
 
+<dom-module id="view-styles">
+    <template>
+        <style>
+            /* Stretch to fill the entire browser viewport while keeping the content constrained to
+            parent element max-width */
+
+            .view-toolbar {
+                display: flex;
+                background-color: var(--lumo-base-color);
+                box-shadow: 0 1px 0 0 var(--lumo-contrast-10pct);
+                margin: 0 calc(-50vw + 50%);
+                padding: 8px calc(50vw - 50% + 16px);
+                position: relative;
+                z-index: 1;
+                flex: none;
+            }
+
+            .view-toolbar__search-field {
+                flex: auto;
+                min-width: 0;
+                margin-right: 16px;
+            }
+            .view-container {
+                margin: 0 calc(-50vw + 50%);
+                padding: 0 calc(50vw - 50% + 16px);
+                flex: auto;
+            }
+        </style>
+    </template>
+</dom-module>
+
+<custom-style>
+    <style include="view-styles">
         html {
             height: auto;
-            background-color: var(--lumo-contrast-5pct);
             --main-layout-header-height: 64px;
         }
 
+        body {
+            background-color: var(--lumo-contrast-5pct);
+        }
+
         .main-layout {
+            display: flex;
+            flex-direction: column;
             width: 100%;
             max-width: 960px;
             margin: 0 auto;
@@ -40,8 +78,13 @@
             font-weight: 500;
         }
 
+        .main-layout > * {
+            flex: auto;
+        }
+
         .main-layout__header {
             display: flex;
+            flex: none;
             align-items: center;
             height: var(--main-layout-header-height);
 
@@ -97,124 +140,53 @@
             box-sizing: border-box;
             pointer-events: none;
         }
-
-
-        /* Category list view styles, placed here because the view is created using the Java API
-          instead of a HTML template */
-        /* In a real project, some of these would be encapsulated in a reusable component instead */
-
-        .categories-list {
-            height: calc(100vh - var(--main-layout-header-height));
-        }
-
-        .view-toolbar {
-            display: flex;
-            background-color: var(--lumo-base-color);
-            box-shadow: 0 1px 0 0 var(--lumo-contrast-5pct);
-            margin: 0 calc(-50vw + 50%);
-            padding: 8px calc(50vw - 50% + 16px);
-            position: relative;
-            z-index: 1;
-        }
-
-        .view-toolbar__search-field {
-            flex: auto;
-            margin-right: 16px;
-        }
-
-        .view-toolbar__button {
-            margin-left: 0;
-            margin-right: 0;
-            min-width: 0;
-            flex: none;
-        }
-
-        vaadin-grid.categories {
-            /* We are not expecting there to be too many categories, so the grid is allowed to grow
-               with the items, and never have its own scrollbar (and load all items immediately) */
-            height: auto;
-            margin: 0 16px;
-            border-width: 0;
-            border-radius: 0 0 var(--lumo-border-radius) var(--lumo-border-radius);
-            box-shadow: 0 0 0 1px var(--lumo-shade-5pct), 0 2px 5px 0 var(--lumo-shade-10pct);
-        }
-
-        /* Small viewport styles */
-
-        @media (max-width: 600px) {
-            .main-layout__header {
-                padding: 0 8px;
-            }
-
-            .view-toolbar {
-                padding: 4px 8px;
-            }
-
-            /* Hide the button label when the browser viewport is narrow */
-            .view-toolbar__button span {
-                display: none;
-            }
-
-            .view-toolbar__button iron-icon {
-                margin: 0;
-            }
-
-            vaadin-grid.categories {
-                margin: 0;
-            }
-        }
-
     </style>
-    <dom-module id="my-notification-styles" theme-for="vaadin-notification-card">
-        <template>
-            <style>
-                [part="overlay"] {
-                    background-color: black !important;
-                }
-                [part="content"]{
-                    color: white !important;
-                }
-            </style>
-        </template>
-    </dom-module>
 
     <dom-module id="my-dialog-styles" theme-for="vaadin-dialog-overlay">
         <template>
-            <style>
-                .confirm-dialog-heading {
-                    text-align: center;
-                    font-size: 19px;
-                    font-weight: 500;
-                    color: var(--lumo-secondary-text-color);
-                    margin-top: 16px;
+            <style include="lumo-color lumo-typography">
+                h3 {
+                    margin-top: 0;
                 }
-                .confirm-dialog-buttons {
-                    padding: 8px;
-                    justify-content: space-between;
+
+                vaadin-form-layout {
+                    max-width: 30em;
                 }
+
                 .buttons {
-                    width: 100%;
-                    box-sizing: border-box;
-                    padding: 16px;
-                    margin-top: 16px;
+                    padding: var(--lumo-space-s) var(--lumo-space-l);
+                    margin: calc(var(--lumo-space-l) * -1);
+                    margin-top: var(--lumo-space-l);
                     border-top: 1px solid var(--lumo-contrast-10pct);
                 }
 
-                .buttons [theme~="danger"] {
+                .buttons > :last-child {
                     margin-left: auto;
                 }
 
-                .has-padding {
-                    padding: 0 16px;
+                .confirm-buttons {
+                    justify-content: space-between;
+                    padding: var(--lumo-space-xs) var(--lumo-space-m);
+                    margin-top: var(--lumo-space-m);
                 }
 
-                .confirm-text div {
-                    margin-bottom: 0.6em;
-                    max-width: 40em;
+                .has-padding {
+                    padding: 0 var(--lumo-space-l);
+                    margin: 0 calc(var(--lumo-space-l) * -1);
                 }
-                .confirm-text div:first-child {
-                    font-weight: 600;
-                    color: var(--lumo-header-text-color);
+
+                .confirm-text {
+                    max-width: 25em;
+                    line-height: var(--lumo-line-height-s);
+                }
+
+                .confirm-text > * {
+                    margin-bottom: 0.6em;
+                }
+
+                .confirm-text div:not(:first-child) {
+                    color: var(--lumo-secondary-text-color);
+                    font-size: var(--lumo-font-size-s);
                 }
             </style>
         </template>


### PR DESCRIPTION
Unify many UI conventions and replace some custom CSS with Lumo styles.

Use the same UI patterns for both views:
- Same header
- Same search behavior (update the view after each keystroke and update the header to show the
- Move duplicate CSS into a shared style module (view-styles)

Unify and improve dialog experience:
- Use consistent language and text formatting
- Refactor dialog styles to look good again
- Allow the user to press Esc to dismiss confirmation dialogs and still return to the previous dialog
- Use Lumo typography styles instead of custom CSS
- Use Lumo badge utility instead of custom CSS
- Remove most responsive styles (not that much benefit) – focus on the review card responsiveness instead

Many small UI fixes, including:
- Use new Lumo “error” style for buttons (prev. “danger”)
- Remove redundant BodySize annotation (this causes the background color to not extend being the first viewport height after scrolling)
- Remove notification visual style overrides. We should use the default visual styles as much as possible. If there are clear improvements needed for those, open issues in the corresponding component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/187)
<!-- Reviewable:end -->
