### PR TITLE
Remove dialog detach logic that is now implemented in the component

### DIFF
--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/AbstractEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/AbstractEditorDialog.java
@@ -124,11 +124,6 @@ public abstract class AbstractEditorDialog<T extends Serializable>
         initButtonBar();
         setCloseOnEsc(true);
         setCloseOnOutsideClick(false);
-        addOpenedChangeListener(event -> {
-            if (!isOpened()) {
-                getElement().removeFromParent();
-            }
-        });
     }
 
     private void initTitle() {

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/ConfirmationDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/common/ConfirmationDialog.java
@@ -66,12 +66,6 @@ class ConfirmationDialog<T extends Serializable>
         titleField.setClassName("confirm-title");
 
         add(titleField, labels, buttonBar);
-
-        this.addOpenedChangeListener(event -> {
-            if (!this.isOpened()){
-                this.getElement().removeFromParent();
-            }
-        });
     }
 
     /**


### PR DESCRIPTION
Detaching the `<vaadin-dialog>` from the DOM when closing the `Dialog` is now implemented in the component level, and it was duplicated here. This caused RPC warnings because the dialogs tried to detach themselves twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/189)
<!-- Reviewable:end -->
