### PR TITLE
Add a stub to fix background color issues.

### DIFF
--- a/src/main/webapp/frontend/styles/shared-styles.html
+++ b/src/main/webapp/frontend/styles/shared-styles.html
@@ -53,6 +53,7 @@
         html {
             height: auto;
             --main-layout-header-height: 64px;
+            background-color: transparent !important;
         }
 
         body {


### PR DESCRIPTION
This does not look like a proper fix, but I have no idea how to fix it otherwise.

The issue is:
* `body` has the  `background-color: var(--lumo-contrast-5pct);` style defined in the project
* html has `background-color: var(--lumo-base-color);` style coming from the theme (?) and it's not overridable in the block I've modified without `!important`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/210)
<!-- Reviewable:end -->
