### PR TITLE
Fixes after verticallayout get default width

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
-        <vaadin.version>10.0.0.beta9</vaadin.version>
-        <flow.maven.plugin.version>1.0.0.beta9</flow.maven.plugin.version>
+        <vaadin.version>10.0.0.beta10</vaadin.version>
+        <flow.maven.plugin.version>1.0.0.beta10</flow.maven.plugin.version>
         <jetty.version>9.3.7.v20160115</jetty.version>
     </properties>
 

--- a/src/main/webapp/frontend/styles/shared-styles.html
+++ b/src/main/webapp/frontend/styles/shared-styles.html
@@ -40,8 +40,6 @@
                 margin-right: 16px;
             }
             .view-container {
-                margin: 0 calc(-50vw + 50%);
-                padding: 0 calc(50vw - 50% + 16px);
                 flex: auto;
             }
         </style>


### PR DESCRIPTION
this is related to set default width to vertical layout
vaadin/vaadin-ordered-layout#55

This patch will not build until the next platform version got released

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/212)
<!-- Reviewable:end -->
