### PR TITLE
The custom-style module is not explicitly imported

### DIFF
--- a/src/main/webapp/frontend/styles/shared-styles.html
+++ b/src/main/webapp/frontend/styles/shared-styles.html
@@ -14,6 +14,7 @@
   ~ the License.
   -->
 
+<link rel="import" href="../bower_components/polymer/lib/elements/custom-style.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/color.html">
 <link rel="import" href="../bower_components/vaadin-lumo-styles/typography.html">
 


### PR DESCRIPTION
https://github.com/vaadin/flow-and-components-documentation/issues/133

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/266)
<!-- Reviewable:end -->
