### PR TITLE
remove watcher from maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,50 +234,7 @@
                                     </arguments>
                                 </configuration>
                             </execution>
-                            <!--
-                                Execute fizzed-watcher asynchronously so that whenever a java
-                                file changes, it'll run `mvn compile` to recompile the project.
-                                Should be not run in production, but maven profiles does not
-                                support multiple property conditions.
-                            -->
-                            <execution>
-                               <id>run-watcher</id>
-                                <phase>test-compile</phase>
-                                <goals><goal>exec</goal></goals>
-                                <configuration>
-                                    <executable>mvn</executable>
-                                    <arguments>
-                                        <argument>fizzed-watcher:run</argument>
-                                    </arguments>
-                                    <async>true</async>
-                                    <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
-                                </configuration>
-                            </execution>
                         </executions>
-                    </plugin>
-
-                    <!--
-                        Watch for the source file changes and recompile the Java classes.
-                        This allows to update npm packages and thus webpack bundle.
-                        Keep in mind that the watcher plugin should be started separately,
-                        since it's a separate project, use `mvn fizzed-watcher:run` or
-                        `./mvnw fizzed-watcher:run` to run it from Maven or use the npm
-                        script that starts it automatically
-                    -->
-                    <plugin>
-                        <groupId>com.fizzed</groupId>
-                        <artifactId>fizzed-watcher-maven-plugin</artifactId>
-                        <version>1.0.6</version>
-                        <configuration>
-                            <watches>
-                                <watch>
-                                    <directory>src/main/java</directory>
-                                </watch>
-                            </watches>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                        </configuration>
                     </plugin>
 
                     <!--


### PR DESCRIPTION
Watcher is not needed anymore since DevMode already is able to update npm files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/327)
<!-- Reviewable:end -->
