### PR TITLE
Use exact name when validating name uniqueness

### DIFF
--- a/src/main/java/com/vaadin/starter/beveragebuddy/backend/CategoryService.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/backend/CategoryService.java
@@ -96,19 +96,21 @@ public class CategoryService {
     }
 
     /**
-     * Searches for the exact category whose name matches the given filter text.
-     *
+     * Fetches the category with the given name.
+     * <p>
      * The matching is case insensitive.
      *
      * @param name
-     *            the filter text
+     *            the category name to look for
      * @return an {@link Optional} containing the category if found, or
      *         {@link Optional#empty()}
      * @throws IllegalStateException
      *             if the result is ambiguous
      */
     public Optional<Category> findCategoryByName(String name) {
-        List<Category> categoriesMatching = findCategories(name);
+        List<Category> categoriesMatching = categories.values().stream()
+                .filter(category -> name.equals(category.getName()))
+                .collect(Collectors.toList());
 
         if (categoriesMatching.isEmpty()) {
             return Optional.empty();
@@ -121,14 +123,14 @@ public class CategoryService {
     }
 
     /**
-     * Fetches the exact category whose name matches the given filter text.
-     *
+     * Fetches the category with the given name.
+     * <p>
      * Behaves like {@link #findCategoryByName(String)}, except that returns a
      * {@link Category} instead of an {@link Optional}. If the category can't be
      * identified, an exception is thrown.
      *
      * @param name
-     *            the filter text
+     *            the category name to look for
      * @return the category, if found
      * @throws IllegalStateException
      *             if not exactly one category matches the given name

--- a/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoryEditorDialog.java
+++ b/src/main/java/com/vaadin/starter/beveragebuddy/ui/views/categorieslist/CategoryEditorDialog.java
@@ -48,8 +48,8 @@ public class CategoryEditorDialog extends AbstractEditorDialog<Category> {
                         "Category name must contain at least 3 printable characters",
                         3, null))
                 .withValidator(
-                        name -> CategoryService.getInstance()
-                                .findCategories(name).size() == 0,
+                        name -> !CategoryService.getInstance()
+                                .findCategoryByName(name).isPresent(),
                         "Category name must be unique")
                 .bind(Category::getName, Category::setName);
     }


### PR DESCRIPTION
Previously, substring matching was used which meant that "Foo" was not a
valid name if "FooBar" also existed.

Fixes #245

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/348)
<!-- Reviewable:end -->
