### PR TITLE
Corrected jetty goal in pre-integration-test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
                         <id>start-jetty</id>
                         <phase>pre-integration-test</phase>
                         <goals>
-                            <goal>deploy-war</goal>
+                            <goal>start</goal>
                         </goals>
                     </execution>
                     <execution>


### PR DESCRIPTION
This was incorrectly set to deploy-war (IT tests erroneously passed with `-Pproduction` mode even when the application was broken in production mode).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/366)
<!-- Reviewable:end -->
