### PR TITLE
Upgrade jetty and chromedriver v14

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -2,10 +2,10 @@
 <root>
     <windows>
         <driver id="googlechrome">
-            <version id="79.0.3945.36">
+            <version id="85.0.4183.83">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_win32.zip</filelocation>
-                    <hash>671dafdf4380e1194268f72278f6c0324f47ae8e</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/85.0.4183.83/chromedriver_win32.zip</filelocation>
+                    <hash>518020edcd75e6f77e3159b683de23337fd38dee</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -13,10 +13,10 @@
     </windows>
     <linux>
         <driver id="googlechrome">
-            <version id="79.0.3945.36">
+            <version id="85.0.4183.83">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_linux64.zip</filelocation>
-                    <hash>3cf7d35a154ad53c7df627ad8d33d70dc941e658</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/85.0.4183.83/chromedriver_linux64.zip</filelocation>
+                    <hash>0d8d70af9e15058db3092fc25ac3f0257f2d3d75</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -24,10 +24,10 @@
     </linux>
     <osx>
         <driver id="googlechrome">
-            <version id="79.0.3945.36">
+            <version id="85.0.4183.83">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_mac64.zip</filelocation>
-                    <hash>a6009cbaadc86cab54982195bb760c64e926cf59</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/85.0.4183.83/chromedriver_mac64.zip</filelocation>
+                    <hash>3053d5ec6b5264bceca72250715b416dc0aedd91</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 
         <drivers.dir>${project.basedir}/drivers</drivers.dir>
         <drivers.downloader.phase>pre-integration-test</drivers.downloader.phase>
+
+        <jetty.version>9.4.28.v20200408</jetty.version>
     </properties>
 
     <repositories>
@@ -131,7 +133,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.15.v20190215</version>
+                <version>${jetty.version}</version>
                 <configuration>
                     <scanIntervalSeconds>1</scanIntervalSeconds>
                 </configuration>
@@ -197,7 +199,7 @@
                     <plugin>
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
-                        <version>9.4.15.v20190215</version>
+                        <version>${jetty.version}</version>
                         <configuration>
                             <scanIntervalSeconds>0</scanIntervalSeconds>
                             <stopPort>8081</stopPort>


### PR DESCRIPTION
Old Jetty had an asm dependency which was incompatible with Java 14.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/beverage-starter-flow/533)
<!-- Reviewable:end -->
